### PR TITLE
Redesign header with sticky behavior and new navigation sections

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -10,6 +10,7 @@ import Footer from './components/Footer';
 
 import Home from './pages/Home';
 import Projects from './pages/Projects';
+import Extras from './pages/Extras';
 import ProfessionalProfile from './pages/ProfessionalProfile/ProfessionalProfile';
 import Contact from './pages/Contact';
 import Knowledge from './pages/Knowledge';
@@ -23,9 +24,10 @@ export default function App() {
         <main className="flex-grow">
           <Routes>
             <Route path="/" element={<Home />} />
-            <Route path="/proyectos" element={<Projects />} />
+            <Route path="/projects" element={<Projects />} />
+            <Route path="/extras" element={<Extras />} />
             <Route path="/profile" element={<ProfessionalProfile />} />
-            <Route path="/contacto" element={<Contact />} />
+            <Route path="/contact" element={<Contact />} />
             <Route path="/knowledge" element={<Knowledge />} />
           </Routes>
         </main>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,6 +10,7 @@ import Footer from './components/Footer'; // ✅ Importar el footer
 
 import Home from './pages/Home';
 import Projects from './pages/Projects';
+import Extras from './pages/Extras';
 import ProfessionalProfile from './pages/ProfessionalProfile/ProfessionalProfile';
 import Contact from './pages/Contact';
 import Knowledge from './pages/Knowledge';
@@ -20,9 +21,10 @@ export default function App() {
       <Navbar />
       <Routes>
         <Route path="/" element={<Home />} />
-        <Route path="/proyectos" element={<Projects />} />
+        <Route path="/projects" element={<Projects />} />
+        <Route path="/extras" element={<Extras />} />
         <Route path="/profile" element={<ProfessionalProfile />} />
-        <Route path="/contacto" element={<Contact />} />
+        <Route path="/contact" element={<Contact />} />
         <Route path="/knowledge" element={<Knowledge />} />
       </Routes>
       <Footer /> {/* ✅ Footer global al final */}

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders Projects link', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
+  const linkElement = screen.getByText(/Projects/i);
   expect(linkElement).toBeInTheDocument();
 });

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -1,49 +1,43 @@
-import React from 'react';
-import { TrendingUp } from 'lucide-react';
-import { Link, useLocation } from 'react-router-dom';
+import React, { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
 
-export default function NavbarHome() {
-  const location = useLocation();
+export default function Navbar() {
+  const [isScrolled, setIsScrolled] = useState(false);
 
-  const navItems = [
-    { label: "Inicio", path: "/" },
-    { label: "Professional Profile", path: "/profile" },
-    { label: "Knowledge Base", path: "/knowledge" },
-    { label: "Proyectos", path: "/proyectos" },
-  ];
+  useEffect(() => {
+    const handleScroll = () => {
+      setIsScrolled(window.scrollY > 0);
+    };
+    window.addEventListener('scroll', handleScroll);
+    return () => window.removeEventListener('scroll', handleScroll);
+  }, []);
 
   return (
-    <nav className="w-full bg-black text-white px-6 py-4 border-b border-gray-700">
-      <div className="max-w-6xl mx-auto flex justify-between items-center">
-        
-        {/* IZQUIERDA: Logo + Lema */}
-        <div className="flex items-center gap-3">
-          <div className="bg-white rounded-sm p-1 flex items-center justify-center">
-            <TrendingUp size={25} className="text-black" />
-          </div>
-          <div className="leading-tight text-sm md:text-base text-gray-300">
-            <div className="flex flex-col justify-center">
-              <span className="block">A value-creating professional</span>
-              <span className="block">for supply chain enterprises</span>
-            </div>
-          </div>
+    <nav
+      className={`fixed top-0 left-0 w-full z-50 font-grotesk transition-colors transition-transform duration-300 ${
+        isScrolled ? 'bg-emerald-400' : 'bg-white'
+      }`}
+    >
+      <div className="h-2 bg-emerald-400" />
+      <div className="flex items-center justify-between px-8 py-4">
+        <div className="flex items-center gap-8 text-black">
+          <div className="border-2 border-black px-2 py-1 font-bold leading-none">ZJ</div>
+          <Link to="/projects" className="hover:text-emerald-600">
+            Projects
+          </Link>
+          <Link to="/extras" className="hover:text-emerald-600">
+            Extras
+          </Link>
+          <Link to="/knowledge" className="hover:text-emerald-600">
+            Knowledge
+          </Link>
         </div>
-
-        {/* DERECHA: Pills de navegación */}
-        <div className="flex gap-4 text-sm font-medium text-white">
-          {navItems.map((item, idx) => (
-            <Link
-              key={idx}
-              to={item.path}
-              className={`px-4 py-2 rounded-full transition-colors duration-200
-                ${location.pathname === item.path
-                  ? 'bg-[#d8fe51] text-black'
-                  : 'hover:bg-[#d8fe51] hover:text-black'}`}
-            >
-              {item.label}
-            </Link>
-          ))}
-        </div>
+        <Link
+          to="/contact"
+          className="border-2 border-black px-4 py-2 text-black transition-colors hover:bg-black hover:text-white"
+        >
+          Contact Me
+        </Link>
       </div>
     </nav>
   );

--- a/src/components/SelectorPill.jsx
+++ b/src/components/SelectorPill.jsx
@@ -2,10 +2,10 @@ import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 const pills = [
-  { label: "Proyectos", path: "/proyectos" },
-  { label: "Knowledge Base", path: "/knowledge" },
-  { label: "Professional Profile", path: "/profile" },
-  { label: "Contacto", path: "/contacto" },
+  { label: "Projects", path: "/projects" },
+  { label: "Extras", path: "/extras" },
+  { label: "Knowledge", path: "/knowledge" },
+  { label: "Contact", path: "/contact" },
 ];
 
 const SelectorPill = () => {

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,5 @@
+@import url('https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;600;700&display=swap');
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/src/pages/Extras.jsx
+++ b/src/pages/Extras.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+const Extras = () => {
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-100">
+      <h1 className="text-2xl font-bold">Extras Page</h1>
+    </div>
+  );
+};
+
+export default Extras;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -5,6 +5,9 @@ module.exports = {
   ],
   theme: {
     extend: {
+      fontFamily: {
+        grotesk: ['"Space Grotesk"', 'sans-serif'],
+      },
       keyframes: {
         fadeWord: {
           '0%': { opacity: '0' },


### PR DESCRIPTION
## Summary
- Add Space Grotesk typography and expose via Tailwind
- Rework Navbar with sticky top bar, color swap on scroll and updated navigation
- Add Extras placeholder page and routes; adjust tests for new header

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68b7073656fc8326b4bafe9cef83143a